### PR TITLE
propagate both genome and seqinfo information from 'subject'

### DIFF
--- a/R/BSgenome-utils.R
+++ b/R/BSgenome-utils.R
@@ -75,6 +75,8 @@ setMethod("vmatchPattern", "BSgenome",
         nms <- nms[unlist(lapply(matches, length), use.names=FALSE) > 0]
         matches <- do.call(c, unname(matches))
         runValue(seqnames(matches)) <- nms
+        genome(matches) <- genome(subject)
+        seqinfo(matches) <- seqinfo(subject)
         matches
     }
 )
@@ -251,6 +253,8 @@ setMethod("vmatchPDict", "BSgenome",
         nms <- nms[unlist(lapply(matches, length), use.names=FALSE) > 0]
         matches <- do.call(c, unname(matches))
         runValue(seqnames(matches)) <- nms
+        genome(matches) <- genome(subject)
+        seqinfo(matches) <- seqinfo(subject)
         matches
     }
 )
@@ -388,6 +392,8 @@ setMethod("matchPWM", "BSgenome",
         string <- factor(mcols(matches)[["string"]])
         mcols(matches)[["string"]] <-
           DNAStringSet(levels(string))[as.integer(string)]
+        genome(matches) <- genome(subject)
+        seqinfo(matches) <- seqinfo(subject)
         matches
     }
 )

--- a/man/BSgenome-utils.Rd
+++ b/man/BSgenome-utils.Rd
@@ -106,6 +106,8 @@
 
 \value{
   A \link[GenomicRanges]{GRanges} object for \code{vmatchPattern}.
+  \code{genome} and \code{seqinfo} information from "subject" are
+  propagated to the return object.
 
   A data.frame object for \code{vcountPattern} and \code{countPWM}
   with three columns: "seqname" (factor), "strand" (factor), and
@@ -113,7 +115,8 @@
 
   A \link[GenomicRanges]{GRanges} object for \code{vmatchPDict} with
   one metadata column: "index", which represents a mapping to a
-  position in the original pattern dictionary.
+  position in the original pattern dictionary. \code{genome} and
+  \code{seqinfo} information from "subject" are propagated.
 
   A \link[S4Vectors]{DataFrame} object for \code{vcountPDict} with four
   columns: "seqname" ('factor' Rle), "strand" ('factor' Rle), 
@@ -123,6 +126,9 @@
 
   A \link[GenomicRanges]{GRanges} object for \code{matchPWM} with two
   metadata columns: "score" (numeric), and "string" (DNAStringSet).
+  \code{genome} and \code{seqinfo} information from "subject" are
+  included.
+
 }
 
 \author{P. Aboyoun}


### PR DESCRIPTION
- affects vmatchPattern, vmatchPDict, and matchPWM
- closes #13